### PR TITLE
(fix) bump Vercel runtime nodejs18.x → nodejs20.x

### DIFF
--- a/svelte.config.js
+++ b/svelte.config.js
@@ -12,7 +12,7 @@ const config = {
 		// If your environment is not supported or you settled on a specific environment, switch out the adapter.
 		// See https://kit.svelte.dev/docs/adapters for more information about adapters.
 		adapter: adapter({
-			runtime: 'nodejs18.x'
+			runtime: 'nodejs20.x'
 		})
 	}
 };


### PR DESCRIPTION
Node 18 EOL — Vercel now rejects it with "invalid runtime" deploy error.